### PR TITLE
Fix OSV scan in GitHub workflow

### DIFF
--- a/.github/workflows/osv-scan.yml
+++ b/.github/workflows/osv-scan.yml
@@ -1,0 +1,55 @@
+name: OSV Scan
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  osv-scan:
+    name: Run OSV-Scanner
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install OSV-Scanner
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/google/osv-scanner/main/scripts/install.sh \
+            | sh -s -- -b /usr/local/bin
+          osv-scanner --version
+
+      - name: Prepare Gradle project (best effort)
+        run: |
+          if [ -f gradlew ]; then
+            chmod +x gradlew
+            ./gradlew --version
+            # Attempt to generate lockfiles to improve scan accuracy; ignore failures
+            ./gradlew dependencies --write-locks || true
+          fi
+
+      - name: Run OSV-Scanner recursively and output SARIF
+        run: |
+          # Do not fail the pipeline on findings; we upload SARIF to Security tab
+          osv-scanner -r . --skip-git --format sarif -o osv-results.sarif || true
+
+      - name: Upload SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: osv-results.sarif
+          category: OSV-Scanner
+
+      - name: Upload OSV results artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: osv-results
+          path: |
+            osv-results.sarif


### PR DESCRIPTION
Add a GitHub Actions workflow to enable OSV-Scanner vulnerability scanning for the `main` branch.

This workflow runs on `push` and `pull_request` events to the `main` branch, installs OSV-Scanner, and includes a best-effort Gradle step for dependency resolution. It performs a recursive scan, uploads the SARIF results to the GitHub Security tab, and is configured not to fail the build on findings by default. Necessary `security-events: write` permissions are granted.

---
<a href="https://cursor.com/background-agent?bcId=bc-b5601aad-b6f3-4852-bb45-c66ef000a333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b5601aad-b6f3-4852-bb45-c66ef000a333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

